### PR TITLE
Update BestieTemplate.jl URL to JuliaBesties

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -9,4 +9,4 @@ PackageName: HadronicLineshapes
 PackageOwner: mmikhasenko
 PackageUUID: 49c9d978-1f9d-4e96-a984-0a9783c0b9bf
 _commit: v0.9.1
-_src_path: https://github.com/abelsiqueira/BestieTemplate.jl
+_src_path: https://github.com/JuliaBesties/BestieTemplate.jl


### PR DESCRIPTION
This is a semi-automated PR.
BestieTemplate.jl has been moved to the JuliaBesties organization.
This updates the URL in .copier-answers.yml to point to the new location.
