### PR TITLE
Typo in BW doc

### DIFF
--- a/docs/src/10-breitwigner.md
+++ b/docs/src/10-breitwigner.md
@@ -21,7 +21,7 @@ This parametrization assumes a single channel decay with no form factors or orbi
 For an elastic resonance with `l`-wave a energy-dependent expression is used for the width,
 
 ```math
-\Gamma(\sigma) = \Gamma_0 \left( \frac{q(\sigma)}{q_0} \right)^{2l+1} \frac{F_l^2(q(\sigma) d)}{F_l^2(q_0 d)}
+\Gamma(\sigma) = \Gamma_0 \left( \frac{q(\sigma)}{q_0} \right)^{2l+1} \frac{m}{\sqrt{\sigma}} \frac{F_l^2(q(\sigma) d)}{F_l^2(q_0 d)}
 ```
 
 where $q = q(\sqrt{\sigma}, m_1, m_2)$ is the momentum of the decay products in the center-of-mass frame,


### PR DESCRIPTION
Add m/sqrt(sigma) term do doc that is in the code and should be there

## Related issues

Closes #24 

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [x] I am following the [contributing guidelines](https://github.com/mmikhasenko/HadronicLineshapes.jl/blob/main/docs/src/90-contributing.md)

- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
